### PR TITLE
call "substitute" rather than "substituteVariable" 

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.1.3</string>
+	<string>1.1.4</string>
 	<key>ServerApiVersion</key>
 	<string>1.0</string>
 	<key>IwsApiVersion</key>

--- a/Contents/Server Plugin/plugin.py
+++ b/Contents/Server Plugin/plugin.py
@@ -27,8 +27,7 @@ class Plugin(indigo.PluginBase):
 		else:
 			strInput = strInput.strip()
 
-			while "%%v:" in strInput:
-				strInput = self.substituteVariable(strInput)
+			strInput = self.substitute(strInput)
 
 			self.debugLog(strInput)
 
@@ -63,7 +62,7 @@ class Plugin(indigo.PluginBase):
 
 		if pluginAction.props['msgPriority'] is not None:
 			params['priority'] = pluginAction.props['msgPriority']
-		
+
 		conn = httplib.HTTPSConnection("api.pushover.net:443")
 		conn.request(
 			"POST",


### PR DESCRIPTION
…so that device states can be filled in as well. Replaced a while loop with a single call to 'substitute' in the process, since it seemed risky to have "while '%%' in strInput' (could cause an infinite loop). If the while loop is really necessary it would have to be more complicated.