### PR TITLE
updated plist format, added license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Indigo Domotics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -3,23 +3,30 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.1.6</string>
+	<string>1.2.0</string>
 	<key>ServerApiVersion</key>
-	<string>1.0</string>
+	<string>2.0</string>
 	<key>IwsApiVersion</key>
 	<string>1.0.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>Pushover</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.thechad.indigoplugin.pushover</string>
+	<string>com.indigodomo.opensource.indigo-pushover</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>https://github.com/IndigoDomotics/indigo-pushover/</string>
+			<string>https://github.com/IndigoDomotics/indigo-pushover</string>
 		</dict>
 	</array>
+	<key>GithubInfo</key>
+	<dict>
+		<key>GithubRepo</key>
+		<string>indigo-pushover</string>
+		<key>GithubUser</key>
+		<string>IndigoDomotics</string>
+	</dict>
 </dict>
 </plist>

--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.2.0</string>
+	<string>1.1.7</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Pushover</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.indigodomo.opensource.indigo-pushover</string>
+	<string>io.thechad.indigoplugin.pushover</string>
 	<key>CFBundleVersion</key>
 	<string>1.0.1</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
was looking over the new rachio plugin noticed several new conventions, updating this plugin to follow suit:
- updated the plist format and values where applicable
- changed `CFBundleIdentifier` to match open source pattern
- bumped version to `1.2.0` (although changing the bundle id might warrant a major version bump)
- added MIT license, but I have no strong opinion if anyone would prefer another

tested on my home installation, no issues thus far. had to delete and re-add any pushover actions since the bundle id changed, but alas...