### PR TITLE
Per-action user key

### DIFF
--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.1.6</string>
+	<string>1.2</string>
 	<key>ServerApiVersion</key>
 	<string>1.0</string>
 	<key>IwsApiVersion</key>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -60,6 +60,12 @@
 			<Field id="hlpMsgPriority" type="label" fontSize="mini" alignWithControl="true">
 				<Label>optional. set to determine priority level. note: setting to 'high priority' or above will override user's quiet hours</Label>
 			</Field>
+			<Field id="msgUser" type="textfield" default="">
+				<Label>User:</Label>
+			</Field>
+			<Field id="hlpMsgUser" type="label" fontSize="mini" alignWithControl="true">
+				<Label>optional. can be used send to a different Pushover user or group key than what is configured in the plugin.</Label>
+			</Field>
 			<Field id="msgDevice" type="textfield" default="">
 				<Label>Device:</Label>
 			</Field>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -4,7 +4,7 @@
 		<Label>API Token:</Label>
 	</Field>
 	<Field id="hlpApiToken" type="label" fontSize="mini" alignWithControl="true">
-		<Label>required. get api key here (https://pushover.net/api).</Label>
+		<Label>required. get api key here (https://pushover.net/apps/clone/indigo_domotics).</Label>
 	</Field>
 	<Field id="userKey" type="textfield" default="">
 		<Label>User Key:</Label>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -50,6 +50,9 @@ class Plugin(indigo.PluginBase):
 		if pluginAction.props['msgDevice'] is not None:
 			params['device'] = pluginAction.props['msgDevice'].strip()
 
+		if pluginAction.props['msgUser'] is not None:
+			params['user'] = pluginAction.props['msgUser'].strip()
+
 		if pluginAction.props['msgSound'] is not None:
 			params['sound'] = pluginAction.props["msgSound"].strip()
 


### PR DESCRIPTION
I have some actions that I want to go to my own Pushover user key, and some to a Pushover group of multiple users.  This allows a user to be configured in the action settings to override the plugin-configured user key.

I'm not sure what your plugin version policy is, but I had to change it to install so I just bumped the minor version.