### PR TITLE
Check for empty string values, not just null

### DIFF
--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -18,6 +18,9 @@ class Plugin(indigo.PluginBase):
 	def shutdown(self):
 		self.debugLog(u"shutdown called")
 
+	def present(self, prop):
+		return (prop and prop.strip() != "")
+
 	# helper functions
 	def prepareTextValue(self, strInput):
 
@@ -47,22 +50,22 @@ class Plugin(indigo.PluginBase):
 		}
 
 		#populate optional parameters
-		if pluginAction.props['msgDevice'] is not None:
+		if self.present(pluginAction.props['msgDevice']):
 			params['device'] = pluginAction.props['msgDevice'].strip()
 
-		if pluginAction.props['msgUser'] is not None:
+		if self.present(pluginAction.props['msgUser']):
 			params['user'] = pluginAction.props['msgUser'].strip()
 
-		if pluginAction.props['msgSound'] is not None:
+		if self.present(pluginAction.props['msgSound']):
 			params['sound'] = pluginAction.props["msgSound"].strip()
 
-		if pluginAction.props['msgSupLinkTitle'] is not None:
+		if self.present(pluginAction.props['msgSupLinkTitle']):
 			params['url_title'] = self.prepareTextValue(pluginAction.props['msgSupLinkTitle'])
 
-		if pluginAction.props['msgSupLinkUrl'] is not None:
+		if self.present(pluginAction.props['msgSupLinkUrl']):
 			params['url'] = self.prepareTextValue(pluginAction.props['msgSupLinkUrl'])
 
-		if pluginAction.props['msgPriority'] is not None:
+		if self.present(pluginAction.props['msgPriority']):
 			params['priority'] = pluginAction.props['msgPriority']
 			if params['priority'] == 2 or params['priority'] == "2":
 				# Require Confirmation priority requires 2 additional params:
@@ -72,8 +75,9 @@ class Plugin(indigo.PluginBase):
 		conn = httplib.HTTPSConnection("api.pushover.net:443")
 		conn.request(
 			"POST",
-			"/1/messages",
+			"/1/messages.json",
 			urllib.urlencode(params),
 			{"Content-type": "application/x-www-form-urlencoded"}
 		)
+		self.debugLog(u"Result: %s" % conn.getresponse().read())
 		conn.close()


### PR DESCRIPTION
This was broken in 570adc73fa because the values coming from `pluginAction.props` are not `None`, they are non-null, blank strings.

Also send result of Pushover API call to the debug log.

Fixes #17