### PR TITLE
Validate that msgBody is not blank

### DIFF
--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -45,11 +45,13 @@ class Plugin(indigo.PluginBase):
 		params = {
 			'token': self.pluginPrefs['apiToken'].strip(),
 			'user': self.pluginPrefs['userKey'].strip(),
-			'title': self.prepareTextValue(pluginAction.props['msgTitle']),
 			'message': self.prepareTextValue(pluginAction.props['msgBody'])
 		}
 
 		#populate optional parameters
+		if self.present(pluginAction.props.get('msgTitle')):
+			params['title'] = self.prepareTextValue(pluginAction.props['msgTitle']).strip()
+
 		if self.present(pluginAction.props.get('msgDevice')):
 			params['device'] = pluginAction.props['msgDevice'].strip()
 

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -50,22 +50,22 @@ class Plugin(indigo.PluginBase):
 		}
 
 		#populate optional parameters
-		if self.present(pluginAction.props['msgDevice']):
+		if self.present(pluginAction.props.get('msgDevice')):
 			params['device'] = pluginAction.props['msgDevice'].strip()
 
-		if self.present(pluginAction.props['msgUser']):
+		if self.present(pluginAction.props.get('msgUser')):
 			params['user'] = pluginAction.props['msgUser'].strip()
 
-		if self.present(pluginAction.props['msgSound']):
+		if self.present(pluginAction.props.get('msgSound')):
 			params['sound'] = pluginAction.props["msgSound"].strip()
 
-		if self.present(pluginAction.props['msgSupLinkTitle']):
+		if self.present(pluginAction.props.get('msgSupLinkTitle')):
 			params['url_title'] = self.prepareTextValue(pluginAction.props['msgSupLinkTitle'])
 
-		if self.present(pluginAction.props['msgSupLinkUrl']):
+		if self.present(pluginAction.props.get('msgSupLinkUrl')):
 			params['url'] = self.prepareTextValue(pluginAction.props['msgSupLinkUrl'])
 
-		if self.present(pluginAction.props['msgPriority']):
+		if self.present(pluginAction.props.get('msgPriority')):
 			params['priority'] = pluginAction.props['msgPriority']
 			if params['priority'] == 2 or params['priority'] == "2":
 				# Require Confirmation priority requires 2 additional params:

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -18,6 +18,16 @@ class Plugin(indigo.PluginBase):
 	def shutdown(self):
 		self.debugLog(u"shutdown called")
 
+	def validateActionConfigUi(self, valuesDict, typeId, deviceId):
+		errorDict = indigo.Dict()
+
+		if typeId == "send":
+			if not self.present(valuesDict.get("msgBody")):
+				errorDict["msgBody"] = "Cannot be blank"
+				return (False, valuesDict, errorDict)
+
+		return (True, valuesDict, errorDict)
+
 	def present(self, prop):
 		return (prop and prop.strip() != "")
 


### PR DESCRIPTION
Also use `.get` instead of `[]` for optional fields to avoid `KeyError`s like [this post](http://forums.indigodomo.com/viewtopic.php?p=154883#p154883) describes, though I'm still not sure why Indigo would be passing a dict without `msgUser`.