### PR TITLE
Provide a cancel action

### DIFF
--- a/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -60,6 +60,12 @@
 			<Field id="hlpMsgPriority" type="label" fontSize="mini" alignWithControl="true">
 				<Label>optional. set to determine priority level. note: setting to 'high priority' or above will override user's quiet hours</Label>
 			</Field>
+			<Field id="msgTags" type="textfield" default="">
+				<Label>Message Tags:</Label>
+			</Field>
+			<Field id="hlpMsgTags" type="label" fontSize="mini" alignWithControl="true">
+				<Label>(Optional) Comma-separated, only used by Emergency-priority notifications and can be used later by Cancel action to cancel retries of this message</Label>
+			</Field>
 			<Field id="msgUser" type="textfield" default="">
 				<Label>User:</Label>
 			</Field>
@@ -83,6 +89,19 @@
 			</Field>
 			<Field id="hlpMsgSupLinkTitle" type="label" fontSize="mini" alignWithControl="true">
 				<Label>optional. a title for your supplementary URL, otherwise just the URL is shown.</Label>
+			</Field>
+			<SupportURL>https://github.com/IndigoDomotics/indigo-pushover/issues</SupportURL>
+		</ConfigUI>
+	</Action>
+	<Action id="cancel" uiPath="NotificationActions">
+		<Name>Cancel Pushover Emergency-Priority Notification</Name>
+		<CallbackMethod>cancel</CallbackMethod>
+		<ConfigUI>
+			<Field id="cancelTag" type="textfield" default="">
+				<Label>Tag:</Label>
+			</Field>
+			<Field id="hlpCancelTag" type="label" fontSize="mini" alignWithControl="true">
+				<Label>Tag that was sent by a notification action with emergency priority, will cancel retries for all notifications with this tag</Label>
 			</Field>
 			<SupportURL>https://github.com/IndigoDomotics/indigo-pushover/issues</SupportURL>
 		</ConfigUI>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -45,11 +45,13 @@ class Plugin(indigo.PluginBase):
 		params = {
 			'token': self.pluginPrefs['apiToken'].strip(),
 			'user': self.pluginPrefs['userKey'].strip(),
-			'title': self.prepareTextValue(pluginAction.props['msgTitle']),
 			'message': self.prepareTextValue(pluginAction.props['msgBody'])
 		}
 
 		#populate optional parameters
+		if self.present(pluginAction.props.get('msgTitle')):
+			params['title'] = self.prepareTextValue(pluginAction.props['msgTitle']).strip()
+
 		if self.present(pluginAction.props.get('msgDevice')):
 			params['device'] = pluginAction.props['msgDevice'].strip()
 

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -25,6 +25,10 @@ class Plugin(indigo.PluginBase):
 			if not self.present(valuesDict.get("msgBody")):
 				errorDict["msgBody"] = "Cannot be blank"
 				return (False, valuesDict, errorDict)
+		elif typeId == "cancel":
+			if not self.present(valuesDict.get("cancelTag")):
+				errorDict["cancelTag"] = "Cannot be blank"
+				return (False, valuesDict, errorDict)
 
 		return (True, valuesDict, errorDict)
 
@@ -84,10 +88,28 @@ class Plugin(indigo.PluginBase):
 				params['retry'] = "600"		# show every 10 minutes until confirmted (could expose UI for this...)
 				params['expire'] = "86400"	# set expire to maximum (24 hours)
 
+				if self.present(pluginAction.props.get('msgTags')):
+					params['tags'] = self.prepareTextValue(pluginAction.props['msgTags'])
+
 		conn = httplib.HTTPSConnection("api.pushover.net:443")
 		conn.request(
 			"POST",
 			"/1/messages.json",
+			urllib.urlencode(params),
+			{"Content-type": "application/x-www-form-urlencoded"}
+		)
+		self.debugLog(u"Result: %s" % conn.getresponse().read())
+		conn.close()
+
+	def cancel(self, pluginAction):
+		params = {
+			'token': self.pluginPrefs['apiToken'].strip(),
+		}
+
+		conn = httplib.HTTPSConnection("api.pushover.net:443")
+		conn.request(
+			"POST",
+			"/1/receipts/cancel_by_tag/" + pluginAction.props['cancelTag'] + ".json",
 			urllib.urlencode(params),
 			{"Content-type": "application/x-www-form-urlencoded"}
 		)

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -50,22 +50,22 @@ class Plugin(indigo.PluginBase):
 		}
 
 		#populate optional parameters
-		if self.present(pluginAction.props['msgDevice']):
+		if self.present(pluginAction.props.get('msgDevice')):
 			params['device'] = pluginAction.props['msgDevice'].strip()
 
-		if self.present(pluginAction.props['msgUser']):
+		if self.present(pluginAction.props.get('msgUser')):
 			params['user'] = pluginAction.props['msgUser'].strip()
 
-		if self.present(pluginAction.props['msgSound']):
+		if self.present(pluginAction.props.get('msgSound')):
 			params['sound'] = pluginAction.props["msgSound"].strip()
 
-		if self.present(pluginAction.props['msgSupLinkTitle']):
+		if self.present(pluginAction.props.get('msgSupLinkTitle')):
 			params['url_title'] = self.prepareTextValue(pluginAction.props['msgSupLinkTitle'])
 
-		if self.present(pluginAction.props['msgSupLinkUrl']):
+		if self.present(pluginAction.props.get('msgSupLinkUrl')):
 			params['url'] = self.prepareTextValue(pluginAction.props['msgSupLinkUrl'])
 
-		if self.present(pluginAction.props['msgPriority']):
+		if self.present(pluginAction.props.get('msgPriority')):
 			params['priority'] = pluginAction.props['msgPriority']
 			if params['priority'] == 2 or params['priority'] == "2":
 				# Require Confirmation priority requires 2 additional params:

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -18,6 +18,16 @@ class Plugin(indigo.PluginBase):
 	def shutdown(self):
 		self.debugLog(u"shutdown called")
 
+	def validateActionConfigUi(self, valuesDict, typeId, deviceId):
+		errorDict = indigo.Dict()
+
+		if typeId == "send":
+			if not self.present(valuesDict.get("msgBody")):
+				errorDict["msgBody"] = "Cannot be blank"
+				return (False, valuesDict, errorDict)
+
+		return (True, valuesDict, errorDict)
+
 	def present(self, prop):
 		return (prop and prop.strip() != "")
 


### PR DESCRIPTION
This was requested in #12 and adds a new action to cancel a previous p2 message based on a tag that is added to the 'send notification' action.

This PR has some commits that depend on #19 so that should get merged first.