### PR TITLE
Add support for entering a custom sound name

### DIFF
--- a/Pushover.indigoPlugin/Contents/Info.plist
+++ b/Pushover.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -67,6 +67,12 @@
 			<Field id="hlpMsgSound" type="label" fontSize="mini" alignWithControl="true">
 				<Label>(Optional) Sound to play on each device instead of device's default sound</Label>
 			</Field>
+			<Field id="msgCustomSound" type="textfield" default="">
+				<Label>Custom Sound:</Label>
+			</Field>
+			<Field id="hlpMsgCustomSound" type="label" fontSize="mini" alignWithControl="true">
+				<Label>(Optional) Custom uploaded sound to play, overriding sound chosen above</Label>
+			</Field>
 			<Field id="msgPriority" type="menu" defaultValue="0">
 				<Label>Priority:</Label>
 				<List>

--- a/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Pushover.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -93,7 +93,9 @@ class Plugin(indigo.PluginBase):
         if self.present(pluginAction.props.get('msgUser')):
             params['user'] = pluginAction.props['msgUser'].strip()
 
-        if self.present(pluginAction.props.get('msgSound')):
+        if self.present(pluginAction.props.get('msgCustomSound')):
+            params['sound'] = pluginAction.props["msgCustomSound"].strip()
+        elif self.present(pluginAction.props.get('msgSound')):
             params['sound'] = pluginAction.props["msgSound"].strip()
 
         if self.present(pluginAction.props.get('msgSupLinkTitle')):


### PR DESCRIPTION
Pushover [supports custom sounds](https://blog.pushover.net/posts/2021/3/custom-sounds) now, so add an additional field to enter a custom-uploaded sound name.  This seems like the easiest way of integrating that without having to parse the sounds API and cache the user's custom sound names.

This also bumps the version to 1.6.1.